### PR TITLE
gas/simple fee market

### DIFF
--- a/contracts/bridge/src/fee-market/SimpleFeeMarket.sol
+++ b/contracts/bridge/src/fee-market/SimpleFeeMarket.sol
@@ -5,7 +5,7 @@ pragma abicoder v2;
 
 import "../interfaces/IFeeMarket.sol";
 
-contract FeeMarket is IFeeMarket {
+contract SimpleFeeMarket is IFeeMarket {
     event SetOwner(address indexed o, address indexed n);
     event SetOutbound(address indexed out, uint256 flag);
     event SetParameters(uint32 slash_time, uint32 relay_time, uint256 collateral);

--- a/contracts/bridge/src/fee-market/SimpleFeeMarket.sol
+++ b/contracts/bridge/src/fee-market/SimpleFeeMarket.sol
@@ -1,0 +1,402 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+pragma abicoder v2;
+
+import "../interfaces/IFeeMarket.sol";
+
+contract FeeMarket is IFeeMarket {
+    event SetOwner(address indexed o, address indexed n);
+    event SetOutbound(address indexed out, uint256 flag);
+    event SetParaTime(uint32 slash_time, uint32 relay_time);
+    event SetParaRelay(uint256 collateral);
+    event Slash(address indexed src, uint wad);
+    event Reward(address indexed dst, uint wad);
+    event Deposit(address indexed dst, uint wad);
+    event Withdrawal(address indexed src, uint wad);
+    event Locked(address indexed src, uint wad);
+    event UnLocked(address indexed src, uint wad);
+    event AddRelayer(address indexed prev, address indexed cur, uint fee);
+    event RemoveRelayer(address indexed prev, address indexed cur);
+    event OrderAssgigned(uint256 indexed key, uint256 timestamp, uint256 collateral, uint256 fee);
+    event OrderSettled(uint256 indexed key, uint timestamp);
+
+    address private constant SENTINEL_HEAD = address(0x1);
+    address private constant SENTINEL_TAIL = address(0x2);
+
+    // SlashAmount = CollateralPerorder * LateTime / SlashTime
+    uint32 public slashTime;
+    // Time assigned relayer to relay messages
+    uint32 public relayTime;
+    // The collateral relayer need to lock for each order.
+    uint256 public collateralPerorder;
+    // Governance role to decide which outbounds message to relay
+    address public owner;
+    // Outbounds which message will be relayed by relayers
+    mapping(address => uint256) public outbounds;
+
+    // Balance of the relayer including deposit and eared fee
+    mapping(address => uint256) public balanceOf;
+    // Locked balance of relayer for relay messages
+    mapping(address => uint256) public lockedOf;
+    // All relayers in fee-market, they are linked one by one and sorted by the relayer fee asc
+    mapping(address => address) public relayers;
+    // relayer count
+    uint256 public relayerCount;
+    // Maker fee of the relayer
+    mapping(address => uint256) public feeOf;
+
+    struct Order {
+        // Assigned time of the order
+        uint32 assignedTime;
+        // assigned_relayer
+        address assignedRelayer;
+        // Assigned collateral of each relayer
+        uint256 collateral;
+        // assigned_relayer_maker_fee
+        uint256 makerFee;
+    }
+    // message_encoded_key => Order
+    mapping(uint256 => Order) public orderOf;
+
+    modifier onlyOwner {
+        require(msg.sender == owner, "!owner");
+        _;
+    }
+
+    modifier onlyOutBound() {
+        require(outbounds[msg.sender] == 1, "!outbound");
+        _;
+    }
+
+    modifier enoughBalance() {
+        require(balanceOf[msg.sender] >= collateralPerorder, "!balance");
+        _;
+    }
+
+    constructor(
+        uint256 _collateral_perorder,
+        uint32 _slash_time,
+        uint32 _relay_time
+    ) {
+        require(_slash_time > 0 && _relay_time > 0, "!0");
+        owner = msg.sender;
+        collateralPerorder = _collateral_perorder;
+        slashTime = _slash_time;
+        relayTime = _relay_time;
+        relayers[SENTINEL_HEAD] = SENTINEL_TAIL;
+        feeOf[SENTINEL_TAIL] = type(uint256).max;
+    }
+
+    receive() external payable {
+        deposit();
+    }
+
+    function setOwner(address _owner) external onlyOwner {
+        owner = _owner;
+        emit SetOwner(owner, _owner);
+    }
+
+    function setOutbound(address out, uint256 flag) external onlyOwner {
+        outbounds[out] = flag;
+        emit SetOutbound(out, flag);
+    }
+
+    function setParaTime(uint32 slash_time, uint32 relay_time) external onlyOwner {
+        require(slash_time > 0 && relay_time > 0, "!0");
+        slashTime = slash_time;
+        relayTime = relay_time;
+        emit SetParaTime(slash_time, relay_time);
+    }
+
+    function setParaRelay(uint256 collateral_perorder) external onlyOwner {
+        collateralPerorder = collateral_perorder;
+        emit SetParaRelay(collateral_perorder);
+    }
+
+    // deposit native token for collateral to relay message
+    // after enroll the relayer and be assigned new message
+    // deposited token will be locked for relay the message
+    function deposit() public payable {
+        balanceOf[msg.sender] += msg.value;
+        emit Deposit(msg.sender, msg.value);
+    }
+
+    // withdraw your free/eared balance anytime.
+    function withdraw(uint wad) public {
+        require(balanceOf[msg.sender] >= wad);
+        balanceOf[msg.sender] -= wad;
+        payable(msg.sender).transfer(wad);
+        emit Withdrawal(msg.sender, wad);
+    }
+
+    function totalSupply() public view returns (uint) {
+        return address(this).balance;
+    }
+
+    // fetch the `count` of order book in fee-market
+    // if flag set true, will ignore their balance
+    // if flag set false, will ensure their balance is sufficient for lock `CollateralPerorder`
+    function getOrderBook(uint count, bool flag) external view returns (uint256, address[] memory, uint256[] memory, uint256 [] memory) {
+        require(count <= relayerCount, "!count");
+        address[] memory array1 = new address[](count);
+        uint256[] memory array2 = new uint256[](count);
+        uint256[] memory array3 = new uint256[](count);
+        uint index = 0;
+        address cur = relayers[SENTINEL_HEAD];
+        while (cur != SENTINEL_TAIL && index < count) {
+            if (flag || balanceOf[cur] >= collateralPerorder) {
+                array1[index] = cur;
+                array2[index] = feeOf[cur];
+                array3[index] = balanceOf[cur];
+                index++;
+            }
+            cur = relayers[cur];
+        }
+        return (index, array1, array2, array3);
+    }
+
+    // find top lowest maker fee relayers
+    function getTopRelayer() public view returns (address top) {
+        require(1 <= relayerCount, "!count");
+        address cur = relayers[SENTINEL_HEAD];
+        while (cur != SENTINEL_TAIL && top != address(0)) {
+            if (balanceOf[cur] >= collateralPerorder) {
+                top = cur;
+            }
+            cur = relayers[cur];
+        }
+        require(top != address(0), "!assigned");
+    }
+
+    // fetch the order fee by the encoded message key
+    function getOrderFee(uint256 key) public view returns (uint256 fee) {
+        fee = orderOf[key].makerFee;
+    }
+
+    function isRelayer(address addr) public view returns (bool) {
+        return addr != SENTINEL_HEAD && addr != SENTINEL_TAIL && relayers[addr] != address(0);
+    }
+
+    // fetch the real time maket fee
+    function market_fee() external view override returns (uint fee) {
+        address top_relayer = getTopRelayer();
+        return feeOf[top_relayer];
+    }
+
+    // deposit native token and enroll to be a relayer at fee-market
+    function enroll(address prev, uint fee) public payable {
+        deposit();
+        addRelayer(prev, fee);
+    }
+
+    // withdraw all balance and remove relayer role at fee-market
+    function unenroll(address prev) public {
+        withdraw(balanceOf[msg.sender]);
+        removeRelayer(prev);
+    }
+
+    // enroll to be a relayer
+    // `prev` is the previous relayer
+    // `fee` is the maker fee to set, PrevFee <= MakerFee <= NextFee
+    function addRelayer(address prev, uint fee) public enoughBalance {
+        address cur = msg.sender;
+        address next = relayers[prev];
+        require(cur != address(0) && cur != SENTINEL_HEAD && cur != SENTINEL_TAIL && cur != address(this), "!valid");
+        // No duplicate relayer allowed.
+        require(relayers[cur] == address(0), "!new");
+        // Prev relayer must in the list.
+        require(next != address(0), "!next");
+        // PrevFee <= MakerFee <= NextFee
+        require(fee >= feeOf[prev], "!>=");
+        require(fee <= feeOf[next], "!<=");
+        relayers[cur] = next;
+        relayers[prev] = cur;
+        feeOf[cur] = fee;
+        relayerCount++;
+        emit AddRelayer(prev, cur, fee);
+    }
+
+    // remove the relayer from the fee-market
+    function removeRelayer(address prev) public {
+        _remove_relayer(prev, msg.sender);
+    }
+
+    function pruneRelayer(address prev, address cur) public {
+        if (lockedOf[cur] == 0 && balanceOf[cur] < collateralPerorder) {
+            _remove_relayer(prev, cur);
+        }
+    }
+
+    // move your position in the fee-market orderbook
+    function moveRelayer(address old_prev, address new_prev, uint new_fee) public {
+        removeRelayer(old_prev);
+        addRelayer(new_prev, new_fee);
+    }
+
+    // Assign new message encoded key to top N relayers in fee-market
+    function assign(uint256 key) public override payable onlyOutBound returns (bool) {
+        //select top N relayers
+        address top_relayer = _get_and_prune_top_relayer();
+        require(isRelayer(top_relayer), "!relayer");
+        uint fee = feeOf[top_relayer];
+        require(msg.value == fee, "!fee");
+        _lock(top_relayer, collateralPerorder);
+        // record the assigned time
+        orderOf[key] = Order(uint32(block.timestamp), top_relayer, collateralPerorder, fee);
+        emit OrderAssgigned(key, block.timestamp, collateralPerorder, fee);
+        return true;
+    }
+
+    // Settle delivered messages and reward/slash relayers
+    function settle(DeliveredRelayer[] calldata delivery_relayers, address confirm_relayer) external override onlyOutBound returns (bool) {
+        _pay_relayers_rewards(delivery_relayers, confirm_relayer);
+        return true;
+    }
+
+    function _get_and_prune_top_relayer() private returns (address top) {
+        require(1 <= relayerCount, "!count");
+        address prev = SENTINEL_HEAD;
+        address cur = relayers[SENTINEL_HEAD];
+        while (cur != SENTINEL_TAIL && top != address(0)) {
+            if (balanceOf[cur] >= collateralPerorder) {
+                top = cur;
+            } else {
+                pruneRelayer(prev, cur);
+            }
+            prev = cur;
+            cur = relayers[cur];
+        }
+        require(top != top, "!assigned");
+    }
+
+    function _remove_relayer(address prev, address cur) private {
+        require(cur != address(0) && cur != SENTINEL_HEAD && cur != SENTINEL_TAIL, "!valid");
+        require(relayers[prev] == cur, "!cur");
+        relayers[prev] = relayers[cur];
+        relayers[cur] = address(0);
+        feeOf[cur] = 0;
+        relayerCount--;
+        emit RemoveRelayer(prev, cur);
+    }
+
+    function _lock(address to, uint wad) private {
+        require(balanceOf[to] >= wad, "!lock");
+        balanceOf[to] -= wad;
+        lockedOf[to] += wad;
+        emit Locked(to, wad);
+    }
+
+    function _unlock(address to, uint wad) private {
+        require(lockedOf[to] >= wad, "!unlock");
+        lockedOf[to] -= wad;
+        balanceOf[to] += wad;
+        emit UnLocked(to, wad);
+    }
+
+    function _slash(address src, uint wad) private {
+        require(lockedOf[src] >= wad, "!slash");
+        lockedOf[src] -= wad;
+        emit Slash(src, wad);
+    }
+
+    function _reward(address dst, uint wad) private {
+        if (wad > 0) {
+            balanceOf[dst] += wad;
+            emit Reward(dst, wad);
+        }
+    }
+
+    /// Pay rewards to given relayers, optionally rewarding confirmation relayer.
+    function _pay_relayers_rewards(DeliveredRelayer[] memory delivery_relayers, address confirm_relayer) private {
+        uint256 total_confirm_reward = 0;
+        for (uint256 i = 0; i < delivery_relayers.length; i++) {
+            DeliveredRelayer memory entry = delivery_relayers[i];
+            uint256 every_delivery_reward = 0;
+            for (uint256 key = entry.begin; key <= entry.end; key++) {
+                require(orderOf[key].assignedTime > 0, "!exist");
+                // diff_time = settle_time - assign_time
+                uint256 diff_time = block.timestamp - orderOf[key].assignedTime;
+                // on time
+                // [0, slot * 1)
+                if (diff_time < relayTime) {
+                    // reward and unlock each assign_relayer
+                    (uint256 delivery_reward, uint256 confirm_reward) = _reward_and_unlock_ontime(key,  entry.relayer, confirm_relayer);
+                    every_delivery_reward += delivery_reward;
+                    total_confirm_reward += confirm_reward;
+                // too late
+                // [slot * 1, +∞)
+                } else {
+                    // slash and unlock each assign_relayer
+                    uint256 late_time = diff_time - relayTime;
+                    (uint256 delivery_reward, uint256 confirm_reward) = _slash_and_unlock_late(key, late_time);
+                    every_delivery_reward += delivery_reward;
+                    total_confirm_reward += confirm_reward;
+                }
+                delete orderOf[key];
+                emit OrderSettled(key, block.timestamp);
+            }
+            // reward every delivery relayer
+            _reward(entry.relayer, every_delivery_reward);
+        }
+        // reward confirm relayer
+        _reward(confirm_relayer, total_confirm_reward);
+    }
+
+    function _reward_and_unlock_ontime(
+        uint256 key,
+        address delivery_relayer,
+        address confirm_relayer
+    ) private returns (uint256 delivery_reward, uint256 confirm_reward) {
+        Order memory order = orderOf[key];
+        address assign_relayer = order.assignedRelayer;
+        // the message delivery in the `slot` assign_relayer
+        (delivery_reward, confirm_reward) = _distribute_ontime(order.makerFee, assign_relayer, delivery_relayer, confirm_relayer);
+        _unlock(assign_relayer, order.collateral);
+    }
+
+    function _slash_and_unlock_late(uint256 key, uint256 late_time) private returns (uint256 delivery_reward, uint256 confirm_reward) {
+        Order memory order = orderOf[key];
+        uint256 message_fee = order.makerFee;
+        uint256 collateral = order.collateral;
+        // slash fee is linear incremental, and the slop is `late_time / SlashTime`
+        uint256 slash_fee = late_time >= slashTime ? collateral : (collateral * late_time / slashTime);
+        address assign_relayer = order.assignedRelayer;
+        _slash(assign_relayer, slash_fee);
+        _unlock(assign_relayer, (collateral - slash_fee));
+        // reward_fee = message_fee + slash_fee
+        (delivery_reward, confirm_reward) = _distribute_fee(message_fee + slash_fee);
+    }
+
+    function _distribute_ontime(
+        uint256 message_fee,
+        address assign_relayer,
+        address delivery_relayer,
+        address confirm_relayer
+    ) private returns (uint256 delivery_reward, uint256 confirm_reward) {
+        if (message_fee > 0) {
+            // 60% * base fee => assigned_relayers_rewards
+            uint256 assign_reward = message_fee * 60 / 100;
+            // 40% * base fee => other relayer
+            uint256 other_reward = message_fee - assign_reward;
+            (delivery_reward, confirm_reward) = _distribute_fee(other_reward);
+            // if assign_relayer == delivery_relayer, we give the reward to delivery_relayer
+            if (assign_relayer == delivery_relayer) {
+                delivery_reward += assign_reward;
+            // if assign_relayer == confirm_relayer, we give the reward to confirm_relayer
+            } else if (assign_relayer == confirm_relayer) {
+                confirm_reward += assign_reward;
+            // both not, we reward the assign_relayer directlly
+            } else {
+                _reward(assign_relayer, assign_reward);
+            }
+        }
+    }
+
+    function _distribute_fee(uint256 fee) private pure returns (uint256 delivery_reward, uint256 confirm_reward) {
+        // 80% * fee => delivery relayer
+        delivery_reward = fee * 80 / 100;
+        // 20% * fee => confirm relayer
+        confirm_reward = fee - delivery_reward;
+    }
+}

--- a/contracts/bridge/src/test/fee-market/SimpleFeeMarket.t.sol
+++ b/contracts/bridge/src/test/fee-market/SimpleFeeMarket.t.sol
@@ -1,0 +1,540 @@
+// SPDX-License-Identifier: Apache-2.0
+
+pragma solidity ^0.8.0;
+
+import "../../../lib/ds-test/src/test.sol";
+import "../../interfaces/IFeeMarket.sol";
+import "../../fee-market/SimpleFeeMarket.sol";
+
+interface Hevm {
+    function warp(uint) external;
+}
+
+contract SimpleFeeMarketTest is DSTest {
+    uint256 constant internal COLLATERAL_PERORDER = 1 ether;
+    uint32  constant internal SLASH_TIME = 1 days;
+    uint32  constant internal RELAY_TIME = 1 days;
+
+    Hevm internal hevm = Hevm(HEVM_ADDRESS);
+    address public self;
+
+    FeeMarket public market;
+    Guy       public a;
+    Guy       public b;
+    Guy       public c;
+
+
+    function setUp() public {
+        market = new FeeMarket(
+            COLLATERAL_PERORDER,
+            SLASH_TIME,
+            RELAY_TIME
+        );
+        self = address(this);
+        a = new Guy(market);
+        b = new Guy(market);
+        c = new Guy(market);
+    }
+
+    function test_constructor_args() public {
+        assertEq(market.owner(), self);
+        assertEq(market.collateralPerorder(), COLLATERAL_PERORDER);
+        assertEq(market.slashTime(), SLASH_TIME);
+        assertEq(market.relayTime(), RELAY_TIME);
+    }
+
+    function test_set_owner() public {
+        market.setOwner(address(0));
+        assertEq(market.owner(), address(0));
+    }
+
+    function test_set_outbound() public {
+        market.setOutbound(self, 1);
+        assertEq(market.outbounds(self), 1);
+    }
+
+    function test_set_paras() public {
+        market.setParameters(2 days, 3 days, 1 wei);
+        assertEq(market.slashTime(), 2 days);
+        assertEq(market.relayTime(), 3 days);
+        assertEq(market.collateralPerorder(), 1 wei);
+    }
+
+    function test_initial_state() public {
+        assert_eth_balance    (a, 0 ether);
+        assert_market_balance (a, 0 ether);
+        assert_eth_balance    (b, 0 ether);
+        assert_market_balance (b, 0 ether);
+        assert_eth_balance    (c, 0 ether);
+        assert_market_balance (c, 0 ether);
+
+        assert_market_supply  (0 ether);
+    }
+
+    function test_join() public {
+        perform_join          (a, 3 ether);
+        assert_market_balance (a, 3 ether);
+        assert_market_balance (b, 0 ether);
+        assert_eth_balance    (a, 0 ether);
+        assert_market_supply  (3 ether);
+
+        perform_join          (a, 4 ether);
+        assert_market_balance (a, 7 ether);
+        assert_market_balance (b, 0 ether);
+        assert_eth_balance    (a, 0 ether);
+        assert_market_supply  (7 ether);
+
+        perform_join          (b, 5 ether);
+        assert_market_balance (b, 5 ether);
+        assert_market_balance (a, 7 ether);
+        assert_market_supply  (12 ether);
+    }
+
+    function testFail_exit_1() public {
+        perform_exit          (a, 1 wei);
+    }
+
+    function testFail_exit_2() public {
+        perform_join          (a, 1 ether);
+        perform_exit          (b, 1 wei);
+    }
+
+    function testFail_exit_3() public {
+        perform_join          (a, 1 ether);
+        perform_join          (b, 1 ether);
+        perform_exit          (b, 1 ether);
+        perform_exit          (b, 1 wei);
+    }
+
+    function test_exit() public {
+        perform_join          (a, 7 ether);
+        assert_market_balance (a, 7 ether);
+        assert_eth_balance    (a, 0 ether);
+
+        perform_exit          (a, 3 ether);
+        assert_market_balance (a, 4 ether);
+        assert_eth_balance    (a, 3 ether);
+
+        perform_exit          (a, 4 ether);
+        assert_market_balance (a, 0 ether);
+        assert_eth_balance    (a, 7 ether);
+    }
+
+    function test_enroll() public {
+        perform_enroll           (a, address(1), 1 ether, 1 ether);
+        assert_market_is_relayer (a);
+        assert_market_fee_of     (a, 1 ether);
+        assert_market_balance    (a, 1 ether);
+        assert_market_supply     (1 ether);
+
+        perform_enroll           (b, address(a), 1 ether, 1 ether);
+        assert_market_is_relayer (b);
+        assert_market_fee_of     (b, 1 ether);
+        assert_market_balance    (b, 1 ether);
+        assert_market_supply     (2 ether);
+
+        perform_enroll           (c, address(b), 1 ether, 1.1 ether);
+        assert_market_is_relayer (c);
+        assert_market_fee_of     (c, 1.1 ether);
+        assert_market_balance    (c, 1 ether);
+        assert_market_supply     (3 ether);
+    }
+
+    function testFail_enroll_1() public {
+        perform_enroll           (a, address(1), 1 ether, 1.1 ether);
+        perform_enroll           (b, address(a), 1 ether, 1 ether);
+    }
+
+    function testFail_enroll_2() public {
+        perform_enroll           (a, address(1), 0.9 ether, 1 ether);
+    }
+
+    function test_unenroll() public {
+        perform_enroll           (a, address(1), 7 ether, 1 ether);
+        assert_market_is_relayer (a);
+        assert_market_fee_of     (a, 1 ether);
+        assert_market_balance    (a, 7 ether);
+        assert_market_supply     (7 ether);
+        assert_eth_balance       (a, 0 ether);
+
+        perform_unenroll         (a, address(1));
+        assert_market_is_not_relayer (a);
+        assert_market_fee_of     (a, 0 ether);
+        assert_market_balance    (a, 0 ether);
+        assert_market_supply     (0 ether);
+        assert_eth_balance       (a, 7 ether);
+    }
+
+    function test_add_relayer() public {
+        perform_join             (a, 3 ether);
+        perform_join             (b, 4 ether);
+        perform_join             (c, 5 ether);
+
+        perform_add_relayer      (a, address     ( 1), 1 ether);
+        assert_market_is_relayer (a);
+        assert_market_fee_of     (a, 1 ether);
+
+        perform_add_relayer      (b, address     ( a), 1 ether);
+        assert_market_is_relayer (b);
+        assert_market_fee_of     (b, 1 ether);
+        perform_add_relayer      (c, address     ( b), 1.1 ether);
+        assert_market_is_relayer (c);
+        assert_market_fee_of     (c, 1.1 ether);
+    }
+
+    function test_remove_relayer() public {
+        perform_enroll           (a, address(1), 1 ether, 1 ether);
+        perform_enroll           (b, address(a), 1 ether, 1 ether);
+        perform_enroll           (c, address(b), 1 ether, 1.1 ether);
+
+        perform_remove_relayer   (a, address(1));
+        assert_market_is_not_relayer (a);
+        assert_market_fee_of     (a, 0 ether);
+        perform_remove_relayer   (b, address(1));
+        assert_market_is_not_relayer (b);
+        assert_market_fee_of     (b, 0 ether);
+        perform_remove_relayer   (c, address(1));
+        assert_market_is_not_relayer (c);
+        assert_market_fee_of     (c, 0 ether);
+    }
+
+    function test_move_relayer() public {
+        perform_enroll           (a, address(1), 1 ether, 1 ether);
+        perform_enroll           (b, address(a), 1 ether, 1 ether);
+        perform_enroll           (c, address(b), 1 ether, 1.1 ether);
+
+        perform_move_relayer     (a, address(1), address(c), 1.2 ether);
+        assert_market_is_relayer (a);
+        assert_market_fee_of     (a, 1.2 ether);
+    }
+
+    function test_market_status() public {
+        perform_enroll           (a, address(1), 1 ether, 1 ether);
+        perform_enroll           (b, address(a), 1 ether, 1 ether);
+        perform_enroll           (c, address(b), 1 ether, 1.1 ether);
+
+        address top = market.getTopRelayer();
+        assertEq(top, address(a));
+
+        (uint index, address[] memory relayers, uint[] memory fees, uint[] memory balances) = market.getOrderBook(3, true);
+        assertEq(index, 3);
+        assertEq(relayers[0], address(a));
+        assertEq(relayers[1], address(b));
+        assertEq(relayers[2], address(c));
+        assertEq(fees[0], 1 ether);
+        assertEq(fees[1], 1 ether);
+        assertEq(fees[2], 1.1 ether);
+        assertEq(balances[0], 1 ether);
+        assertEq(balances[1], 1 ether);
+        assertEq(balances[2], 1 ether);
+    }
+
+    function test_assign() public {
+        uint key = 1;
+        init(key);
+        (uint index, address[] memory relayers, uint[] memory fees, uint[] memory balances) = market.getOrderBook(1, false);
+        assertEq(index, 1);
+        assertEq(relayers[0], address(b));
+        assertEq(fees[0], market.feeOf(address(b)));
+        assertEq(balances[0], 1 ether);
+
+        assert_market_locked(a, 1 ether);
+        assert_market_locked(b, 0 ether);
+        assert_market_locked(c, 0 ether);
+
+        assert_market_order(a, key);
+    }
+
+    function test_settle_when_a_relay_and_confirm_at_a_slot() public {
+        hevm.warp(1);
+        uint key = 1;
+        init(key);
+
+        assert_market_balance(a, 0 ether);
+        assert_market_balance(b, 1 ether);
+        assert_market_balance(c, 1 ether);
+        assert_market_locked(a, 1 ether);
+        assert_market_locked(b, 0 ether);
+        assert_market_locked(c, 0 ether);
+        assert_market_supply(4 ether);
+
+        IFeeMarket.DeliveredRelayer[] memory deliveredRelayers = newDeliveredRelayers(a, key);
+        assertTrue(market.settle(deliveredRelayers, address(a)));
+
+        assert_market_order_clean(key);
+
+        assert_market_balance(a, 2 ether);
+        assert_market_balance(b, 1 ether);
+        assert_market_balance(c, 1 ether);
+        assert_market_balances();
+        assert_market_supply(4 ether);
+    }
+
+    function test_settle_when_a_relay_and_b_confirm_at_a_slot() public {
+        hevm.warp(1);
+        uint key = 1;
+        init(key);
+
+        IFeeMarket.DeliveredRelayer[] memory deliveredRelayers = newDeliveredRelayers(a, key);
+        assertTrue(market.settle(deliveredRelayers, address(b)));
+
+        assert_market_order_clean(key);
+
+        assert_market_balance(a, 1.92 ether);
+        assert_market_balance(b, 1.08 ether);
+        assert_market_balance(c, 1 ether);
+        assert_market_balances();
+        assert_market_supply(4 ether);
+    }
+
+    function test_settle_when_b_relay_and_c_confirm_at_a_slot() public {
+        hevm.warp(1);
+        uint key = 1;
+        init(key);
+
+        IFeeMarket.DeliveredRelayer[] memory deliveredRelayers = newDeliveredRelayers(b, key);
+        assertTrue(market.settle(deliveredRelayers, address(c)));
+
+        assert_market_order_clean(key);
+
+        assert_market_balance(a, 1.6 ether);
+        assert_market_balance(b, 1.32 ether);
+        assert_market_balance(c, 1.08 ether);
+        assert_market_balances();
+        assert_market_supply(4 ether);
+    }
+
+    function test_settle_when_a_relay_and_a_confirm_at_a_slot() public {
+        hevm.warp(1);
+        uint key = 1;
+        init(key);
+
+        hevm.warp(1 + RELAY_TIME);
+        IFeeMarket.DeliveredRelayer[] memory deliveredRelayers = newDeliveredRelayers(a, key);
+        assertTrue(market.settle(deliveredRelayers, address(a)));
+
+        assert_market_order_clean(key);
+
+        assert_market_balance(a, 2 ether);
+        assert_market_balance(b, 1 ether);
+        assert_market_balance(c, 1 ether);
+        assert_market_balances();
+        assert_market_supply(4 ether);
+    }
+
+    function test_settle_when_b_relay_and_b_confirm_at_a_slot_late() public {
+        hevm.warp(1);
+        uint key = 1;
+        init(key);
+
+        hevm.warp(1 + RELAY_TIME);
+        IFeeMarket.DeliveredRelayer[] memory deliveredRelayers = newDeliveredRelayers(b, key);
+        assertTrue(market.settle(deliveredRelayers, address(b)));
+
+        assert_market_order_clean(key);
+
+        assert_market_balance(a, 1 ether);
+        assert_market_balance(b, 2 ether);
+        assert_market_balance(c, 1 ether);
+        assert_market_balances();
+        assert_market_supply(4 ether);
+    }
+
+    function test_settle_when_a_relay_and_b_confirm_late_half_slash() public {
+        hevm.warp(1);
+        uint key = 1;
+        init(key);
+
+        hevm.warp(1 + RELAY_TIME + SLASH_TIME / 2);
+        IFeeMarket.DeliveredRelayer[] memory deliveredRelayers = newDeliveredRelayers(a, key);
+        assertTrue(market.settle(deliveredRelayers, address(b)));
+
+        assert_market_order_clean(key);
+
+        assert_market_balance(a, 1.7 ether);
+        assert_market_balance(b, 1.3 ether);
+        assert_market_balance(c, 1 ether);
+        assert_market_balances();
+        assert_market_supply(4 ether);
+    }
+
+    function test_settle_when_a_relay_and_b_confirm_late_all_slash() public {
+        hevm.warp(1);
+        uint key = 1;
+        init(key);
+
+        hevm.warp(1 + RELAY_TIME + SLASH_TIME);
+        IFeeMarket.DeliveredRelayer[] memory deliveredRelayers = newDeliveredRelayers(a, key);
+        assertTrue(market.settle(deliveredRelayers, address(b)));
+
+        assert_market_order_clean(key);
+
+        assert_market_balance(a, 1.6 ether);
+        assert_market_balance(b, 1.4 ether);
+        assert_market_balance(c, 1 ether);
+        assert_market_balances();
+        assert_market_supply(4 ether);
+    }
+
+    function test_settle_when_b_relay_and_b_confirm_late_all_slash() public {
+        hevm.warp(1);
+        uint key = 1;
+        init(key);
+
+        hevm.warp(1 + RELAY_TIME + SLASH_TIME);
+        IFeeMarket.DeliveredRelayer[] memory deliveredRelayers = newDeliveredRelayers(b, key);
+        assertTrue(market.settle(deliveredRelayers, address(b)));
+
+        assert_market_order_clean(key);
+
+        assert_market_balance(a, 0 ether);
+        assert_market_balance(b, 3 ether);
+        assert_market_balance(c, 1 ether);
+        assert_market_balances();
+        assert_market_supply(4 ether);
+    }
+
+    //------------------------------------------------------------------
+    // Helper functions
+    //------------------------------------------------------------------
+
+    function init(uint key) public {
+        market.setOutbound(self, 1);
+        perform_enroll           (a, address(1), 1 ether, 1 ether);
+        perform_enroll           (b, address(a), 1 ether, 1 ether);
+        perform_enroll           (c, address(b), 1 ether, 1.1 ether);
+
+        perform_assign(key, 1 ether);
+    }
+
+    function newDeliveredRelayers(Guy relayer, uint key) public pure returns (IFeeMarket.DeliveredRelayer[] memory) {
+        IFeeMarket.DeliveredRelayer[] memory deliveredRelayers = new IFeeMarket.DeliveredRelayer[](1);
+        deliveredRelayers[0] = IFeeMarket.DeliveredRelayer(address(relayer), key, key);
+        return deliveredRelayers;
+    }
+
+    function assert_eth_balance(Guy guy, uint balance) public {
+        assertEq(address(guy).balance, balance);
+    }
+
+    function assert_market_balance(Guy guy, uint balance) public {
+        assertEq(market.balanceOf(address(guy)), balance);
+    }
+
+    function assert_market_balances() public {
+        uint ba = market.balanceOf(address(a));
+        uint bb = market.balanceOf(address(b));
+        uint bc = market.balanceOf(address(c));
+        assertEq(ba + bb + bc, market.totalSupply());
+    }
+
+    function assert_market_locked(Guy guy, uint locked) public {
+        assertEq(market.lockedOf(address(guy)), locked);
+    }
+
+    function assert_market_order(Guy guy, uint key) public {
+        (uint32 assignedTime, address assignedRelayer, uint collateral, uint fee) = market.orderOf(key);
+        assertEq(assignedTime, block.timestamp);
+        assertEq(collateral, COLLATERAL_PERORDER);
+        assertEq(assignedRelayer, address(guy));
+        assertEq(fee, market.feeOf(assignedRelayer));
+    }
+
+    function assert_market_order_clean(uint key) public {
+        (uint32 assignedTime, address assignedRelayer, uint collateral, uint fee) = market.orderOf(key);
+        assertEq(assignedTime, 0);
+        assertEq(assignedRelayer, address(0));
+        assertEq(collateral, 0);
+        assertEq(fee, 0);
+
+        assert_market_locked(a, 0 ether);
+        assert_market_locked(b, 0 ether);
+        assert_market_locked(c, 0 ether);
+    }
+
+    function assert_market_supply(uint supply) public {
+        assertEq(market.totalSupply(), supply);
+    }
+
+    function assert_market_is_relayer(Guy guy) public {
+        assertTrue(market.isRelayer(address(guy)));
+    }
+
+    function assert_market_is_not_relayer(Guy guy) public {
+        assertTrue(!market.isRelayer(address(guy)));
+    }
+
+    function assert_market_fee_of(Guy guy, uint fee) public {
+        assertEq(market.feeOf(address(guy)), fee);
+    }
+
+    function perform_join(Guy guy, uint wad) public {
+        guy.join{value: wad}();
+    }
+
+    function perform_exit(Guy guy, uint wad) public {
+        guy.exit(wad);
+    }
+
+    function perform_enroll(Guy guy, address prev, uint wad, uint fee) public {
+        guy.enroll{value: wad}(prev, fee);
+    }
+
+    function perform_unenroll(Guy guy, address prev) public {
+        guy.unenroll(prev);
+    }
+
+    function perform_add_relayer(Guy guy, address prev, uint fee) public {
+        guy.addRelayer(prev, fee);
+    }
+
+    function perform_remove_relayer(Guy guy, address prev) public {
+        guy.removeRelayer(prev);
+    }
+
+    function perform_move_relayer(Guy guy, address old_prev, address new_prev, uint new_fee) public {
+        guy.moveRelayer(old_prev, new_prev, new_fee);
+    }
+
+    function perform_assign(uint key, uint wad) public {
+        market.assign{value: wad}(key);
+    }
+}
+
+contract Guy {
+    FeeMarket market;
+
+    constructor(FeeMarket _market) {
+        market = _market;
+    }
+
+    receive() payable external {}
+
+    function join() payable public {
+        market.deposit{value: msg.value}();
+    }
+
+    function exit(uint wad) public {
+        market.withdraw(wad);
+    }
+
+    function enroll(address prev, uint fee) payable public {
+        market.enroll{value: msg.value}(prev, fee);
+    }
+
+    function unenroll(address prev) public {
+        market.unenroll(prev);
+    }
+
+    function addRelayer(address prev, uint fee) public {
+        market.addRelayer(prev, fee);
+    }
+
+    function removeRelayer(address prev) public {
+        market.removeRelayer(prev);
+    }
+
+    function moveRelayer(address old_prev, address new_prev, uint new_fee) public {
+        market.moveRelayer(old_prev, new_prev, new_fee);
+    }
+}

--- a/contracts/bridge/src/test/fee-market/SimpleFeeMarket.t.sol
+++ b/contracts/bridge/src/test/fee-market/SimpleFeeMarket.t.sol
@@ -18,14 +18,14 @@ contract SimpleFeeMarketTest is DSTest {
     Hevm internal hevm = Hevm(HEVM_ADDRESS);
     address public self;
 
-    FeeMarket public market;
+    SimpleFeeMarket public market;
     Guy       public a;
     Guy       public b;
     Guy       public c;
 
 
     function setUp() public {
-        market = new FeeMarket(
+        market = new SimpleFeeMarket(
             COLLATERAL_PERORDER,
             SLASH_TIME,
             RELAY_TIME
@@ -502,9 +502,9 @@ contract SimpleFeeMarketTest is DSTest {
 }
 
 contract Guy {
-    FeeMarket market;
+    SimpleFeeMarket market;
 
-    constructor(FeeMarket _market) {
+    constructor(SimpleFeeMarket _market) {
         market = _market;
     }
 

--- a/contracts/bridge/test/test_normal_send_message_single_with_simple_fee_market.js
+++ b/contracts/bridge/test/test_normal_send_message_single_with_simple_fee_market.js
@@ -1,0 +1,108 @@
+const { expect } = require("chai");
+const { solidity } = require("ethereum-waffle");
+const chai = require("chai");
+const { Fixure } = require("./shared/fixture")
+
+chai.use(solidity);
+const log = console.log
+const thisChainPos = 0
+const thisLanePos = 0
+const bridgedChainPos = 1
+const bridgedLanePos = 1
+let owner, addr1, addr2
+let feeMarket, outbound, inbound, normalApp
+let outboundData, inboundData
+let fee = ethers.utils.parseEther("30")
+let overrides = { value: fee }
+
+const batch = 1
+const encoded = "0x"
+const send_message = async (nonce) => {
+    let to = normalApp.address
+    const tx = await outbound.send_message(
+      to,
+      encoded,
+      overrides
+    )
+    await expect(tx)
+      .to.emit(outbound, "MessageAccepted")
+      .withArgs(nonce, encoded)
+    await logNonce()
+}
+
+const logNonce = async () => {
+  const out = await outbound.outboundLaneNonce()
+  const iin = await inbound.inboundLaneNonce()
+  log(`(${out.latest_received_nonce}, ${out.latest_generated_nonce}]                                            ->     (${iin.last_confirmed_nonce}, ${iin.last_delivered_nonce}]`)
+}
+
+const receive_messages_proof = async (nonce) => {
+    laneData = await outbound.data()
+    const from = (await inbound.inboundLaneNonce()).last_delivered_nonce.toNumber()
+    const size = nonce - from
+    const calldata = Array(laneData.messages.length).fill(encoded)
+    let relayer = ethers.Wallet.createRandom();
+    await owner.sendTransaction({
+        to: relayer.address,
+        value: ethers.utils.parseEther("1.0")
+    })
+    relayer = relayer.connect(ethers.provider)
+    const tx = await inbound.connect(relayer).receive_messages_proof(laneData, calldata, "0x", {
+      gasLimit: 10000000
+    })
+    for (let i = 0; i<size; i++) {
+      await expect(tx)
+        .to.emit(inbound, "MessageDispatched")
+        .withArgs(thisChainPos, thisLanePos, bridgedChainPos, bridgedLanePos, from+i+1, true, "0x")
+    }
+    await logNonce()
+}
+
+const receive_messages_delivery_proof = async (begin, end) => {
+    laneData = await inbound.data()
+    const tx = await outbound.connect(addr1).receive_messages_delivery_proof(laneData, "0x")
+    await expect(tx)
+      .to.emit(outbound, "MessagesDelivered")
+      .withArgs(begin, end, 1)
+    await logNonce()
+}
+
+//   out bound lane                                    ->           in bound lane
+//   (latest_received_nonce, latest_generated_nonce]   ->     (last_confirmed_nonce, last_delivered_nonce]
+//0  (0,  1]   #send_message                            ->     (0, 0]
+//1  (0,  1]                                            ->     (0, 1]  #receive_messages_proof
+//2  (1 , 1]   #receive_messages_delivery_proof         ->     (0, 1]
+describe("normal app send single message tests", () => {
+
+  before(async () => {
+    ({ feeMarket, outbound, inbound } = await waffle.loadFixture(Fixure));
+    [owner, addr1, addr2] = await ethers.getSigners();
+
+    const SimpleFeeMarket = await ethers.getContractFactory("SimpleFeeMarket")
+    feeMarket = await SimpleFeeMarket.deploy(ethers.utils.parseEther("10"), 100, 100)
+
+    let overrides = { value: ethers.utils.parseEther("3000") }
+    await feeMarket.connect(owner).enroll("0x0000000000000000000000000000000000000001", fee, overrides)
+    await outbound.setFeeMarket(feeMarket.address)
+
+    const NormalApp = await ethers.getContractFactory("NormalApp")
+    normalApp = await NormalApp.deploy()
+    outbound.rely(normalApp.address)
+    log(" out bound lane                                   ->      in bound lane")
+    log("(latest_received_nonce, latest_generated_nonce]   ->     (last_confirmed_nonce, last_delivered_nonce]")
+  })
+
+  it("0", async function () {
+    for(let i=1; i <=batch; i++) {
+      await send_message(i)
+    }
+  })
+
+  it("1", async function () {
+    await receive_messages_proof(batch)
+  })
+
+  it("2", async function () {
+    await receive_messages_delivery_proof(1, batch)
+  })
+})


### PR DESCRIPTION
## Simply fee market logic
- decrease `assignedRelayersNumber` from 3 to 1.
- remove VAULT for receiving surplus, because of message fee equal to base fee.
- combine `Order` and `OrderExt` to `Order`.

### FeeMarket gas used
```
yarn test test/test_normal_send_message_single.js

·----------------------------------------------------|---------------------------|----------------|-----------------------------·
|                Solc version: 0.8.11                ·  Optimizer enabled: true  ·  Runs: 999999  ·  Block limit: 12450000 gas  │
·····················································|···························|················|······························
|  Methods                                                                                                                      │
·················|···································|·············|·············|················|···············|··············
|  Contract      ·  Method                           ·  Min        ·  Max        ·  Avg           ·  # calls      ·  eur (avg)  │
·················|···································|·············|·············|················|···············|··············
|  InboundLane   ·  receive_messages_proof           ·          -  ·          -  ·        121201  ·            2  ·          -  │
·················|···································|·············|·············|················|···············|··············
|  OutboundLane  ·  receive_messages_delivery_proof  ·          -  ·          -  ·        110036  ·            2  ·          -  │
·················|···································|·············|·············|················|···············|··············
|  OutboundLane  ·  send_message                     ·          -  ·          -  ·        412714  ·            2  ·          -  │
·················|···································|·············|·············|················|···············|··············
```

### SimpleFeeMarket gas used
```
yarn test test/test_normal_send_message_single_with_simple_fee_market.js

·-------------------------------------------------------|---------------------------|----------------|-----------------------------·
|                 Solc version: 0.8.11                  ·  Optimizer enabled: true  ·  Runs: 999999  ·  Block limit: 12450000 gas  │
························································|···························|················|······························
|  Methods                                                                                                                         │
····················|···································|·············|·············|················|···············|··············
|  Contract         ·  Method                           ·  Min        ·  Max        ·  Avg           ·  # calls      ·  eur (avg)  │
····················|···································|·············|·············|················|···············|··············
|  InboundLane      ·  receive_messages_proof           ·          -  ·          -  ·        121201  ·            2  ·          -  │
····················|···································|·············|·············|················|···············|··············
|  OutboundLane     ·  receive_messages_delivery_proof  ·          -  ·          -  ·         85393  ·            2  ·          -  │
····················|···································|·············|·············|················|···············|··············
|  OutboundLane     ·  send_message                     ·          -  ·          -  ·        228471  ·            2  ·          -  │
····················|···································|·············|·············|················|···············|··············
```

### Gas comparing
`SimpleFeeMarket` reduce ~ 44% gas in `send_message`
`SimpleFeeMarket` reduce ~ 22% gas in `receive_messages_delivery_proof`

